### PR TITLE
Improve regex 

### DIFF
--- a/server/summarizeMe.py
+++ b/server/summarizeMe.py
@@ -19,10 +19,9 @@ def summarize(text):
     news = text
     summarySize = 0; # Store size of summary to retrieve stats
 
-    # Avoid punctuation signs
-    words = re.findall(r"[a-zA-Z_'-]+", news)
-    sentences = sent_tokenize(news)
-
+    # RegexpTokenizer used to avoid punctuation signs
+    tokenizer = RegexpTokenizer(r"[a-zA-Z_']+")
+    words = tokenizer.tokenize(news)
 
     # Retrieve set to remove stopwords from analysis
     stopWords = set(stopwords.words("english"))

--- a/server/summarizeMe.py
+++ b/server/summarizeMe.py
@@ -19,10 +19,10 @@ def summarize(text):
     news = text
     summarySize = 0; # Store size of summary to retrieve stats
 
-    # RegexpTokenizer used to avoid punctuation signs
-    tokenizer = RegexpTokenizer(r"\w+")
-    words = tokenizer.tokenize(news)
+    # Avoid punctuation signs
+    words = re.findall(r"[a-zA-Z_'-]+", news)
     sentences = sent_tokenize(news)
+
 
     # Retrieve set to remove stopwords from analysis
     stopWords = set(stopwords.words("english"))


### PR DESCRIPTION
Improve regex to treat contracted words as one and treat words containing a hyphen as one word.

Eg
This contracted word is treated as two distinct ones: `it's` -> `["it", "s"]`
It would be better if it was treated as one word.